### PR TITLE
Make connection establishing smarter

### DIFF
--- a/lib/active_replicas/rails4/process_local_connection_handler.rb
+++ b/lib/active_replicas/rails4/process_local_connection_handler.rb
@@ -41,6 +41,9 @@ module ActiveReplicas
 
           clear_all_connections!
           initialize_pools
+
+          # Rails returns a connection pool.
+          retrieve_connection_pool owner
         end
       end
 

--- a/lib/active_replicas/rails4/process_local_connection_handler.rb
+++ b/lib/active_replicas/rails4/process_local_connection_handler.rb
@@ -13,12 +13,7 @@ module ActiveReplicas
 
       def initialize(proxy_configuration)
         @proxy_configuration = proxy_configuration
-
-        @primary_pool = Helpers.connection_pool_for_spec @proxy_configuration[:primary]
-
-        @replica_pools = (@proxy_configuration[:replicas] || {}).map do |name, config_spec|
-          [name, Helpers.connection_pool_for_spec(config_spec)]
-        end.to_h
+        initialize_pools
 
         # Each thread gets its own `ProxyingConnectionPool`.
         @reserved_proxies = Concurrent::Map.new
@@ -33,10 +28,20 @@ module ActiveReplicas
 
       def establish_connection(owner, spec)
         prefix = '[ActiveReplicas::Rails4::ConnectionHandler#establish_connection]'
-        ActiveRecord::Base.logger&.warn "#{prefix} Ignoring spec for #{owner.inspect}: #{spec.inspect}"
-        ActiveRecord::Base.logger&.info "#{prefix} Called from:\n" + Kernel.caller.first(5).map {|t| "  #{t}" }.join("\n")
+        details = "#{spec.config.inspect} (owner: #{owner.inspect})"
 
-        current_proxy
+        synchronize do
+          if @proxy_configuration[:primary] == spec.config
+            ActiveRecord::Base.logger&.warn "#{prefix} Ignoring new spec as it matches existing primary spec: #{details}"
+          else
+            ActiveRecord::Base.logger&.warn "#{prefix} Overwriting connection spec: #{details}"
+            ActiveRecord::Base.logger&.info "#{prefix} Called from:\n" + Kernel.caller.map {|t| "  #{t}" }.join("\n")
+            @proxy_configuration = { primary: spec.config }
+          end
+
+          clear_all_connections!
+          initialize_pools
+        end
       end
 
       def active_connections?
@@ -113,6 +118,18 @@ module ActiveReplicas
 
       def current_thread_id
         Thread.current.object_id
+      end
+
+      private
+
+      # Sets up `@primary_pool` and `@replica_pools` from the current
+      # `@proxy_configuration`.
+      def initialize_pools
+        @primary_pool = Helpers.connection_pool_for_spec @proxy_configuration[:primary]
+
+        @replica_pools = (@proxy_configuration[:replicas] || {}).map do |name, config_spec|
+          [name, Helpers.connection_pool_for_spec(config_spec)]
+        end.to_h
       end
     end
   end

--- a/spec/active_replicas/rails4/connection_handler_spec.rb
+++ b/spec/active_replicas/rails4/connection_handler_spec.rb
@@ -16,10 +16,14 @@ describe ActiveReplicas::Rails4::ConnectionHandler, if: is_rails4 do
 
   describe '#remove_connection' do
     it "turns off reconnects, disconnects, and returns the primary's config" do
-      @handler.establish_connection nil, nil
+      primary_config = { adapter: 'sqlite3', database: 'tmp/primary.sqlite3' }
+
+      spec = double 'connection specification', config: primary_config
+
+      @handler.establish_connection nil, spec
 
       config = @handler.remove_connection nil
-      expect(config).to eq({ adapter: 'sqlite3', database: 'tmp/primary.sqlite3' })
+      expect(config).to eq(primary_config)
     end
   end
 


### PR DESCRIPTION
There were a couple cases where we need to be optimistic about preserving existing connection setups when `#establish_connection` is called:

1. Some gems are paranoid and call `#remove_connection` and `#establish_connection` (`activerecord-import` is the primary offender for this).
2. Rails will remove and re-restablish connections in Rake tasks.

For both of these cases we want to be optimistic and preserve our existing primary-replica configuration if the new connection specification matches the primary pool's specification. This is so that our primary-replica configuration doesn't get tossed out every time a spurious remove-and-establish happens.